### PR TITLE
added no-op statements to remove warnings

### DIFF
--- a/TeensyID.cpp
+++ b/TeensyID.cpp
@@ -117,6 +117,7 @@ const char* teensyMAC(void) {
 
 #if defined ARDUINO_TEENSY40 || defined ARDUINO_TEENSY41
 	void kinetisUID(uint32_t *uid) {
+		(void)uid; // suppress warn unused parameter 'uid'
 		}
 
 	const char* kinetisUID(void) {
@@ -161,6 +162,7 @@ const char* teensyMAC(void) {
 #if defined ARDUINO_TEENSY40  || defined ARDUINO_TEENSY41
 
 	void teensyUUID(uint8_t *uuid) {
+		(void)uuid; // suppress warn unused parameter 'uuid'
 		}
 
 	const char* teensyUUID(void) {


### PR DESCRIPTION
Hey!
First, great lib ! very simple, useful and intuitive.
If I understand correctly these 2 methods are meant to be empty.
if so, having those warning adds noise to gcc's output with -Wall :

.pio/libdeps/debug/TeensyID/TeensyID.cpp:119:28: warning: unused parameter 'uid' [-Wunused-parameter]
  void kinetisUID(uint32_t *uid) {
                            ^
.....
.pio/libdeps/debug/TeensyID/TeensyID.cpp:163:27: warning: unused parameter 'uuid' [-Wunused-parameter]
  void teensyUUID(uint8_t *uuid) {
.....

I made a patch that adds no assembly but suppresses undue warnings.

Source for the method : https://stackoverflow.com/questions/1486904/how-do-i-best-silence-a-warning-about-unused-variables
