### PR TITLE
implemented teensyBoardVersion()

### DIFF
--- a/TeensyID.cpp
+++ b/TeensyID.cpp
@@ -224,4 +224,58 @@ const char* teensyUID64(void) {
 
 #endif
 
+#if defined ARDUINO_TEENSY41
+ const char* teensyBoardVersion(void) {
+     static char boardVersion[16] = "Teensy 4.1";
+     return boardVersion;
+ }
+
+#elif defined ARDUINO_TEENSY40
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 4.0";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSYLC
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy LC";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSY36
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 3.6";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSY35
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 3.5";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSY32
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 3.2";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSY31
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 3.1";
+ return boardVersion;
+}
+
+#elif defined ARDUINO_TEENSY30
+const char* teensyBoardVersion(void) {
+ static char boardVersion[16] = "Teensy 3.0";
+ return boardVersion;
+}
+
+#else 
+const char* teensyBoardVersion(void) {
+    static char boardVersion[16] = "Unknown Teensy";
+    return boardVersion;
+   }
+#endif
 

--- a/TeensyID.h
+++ b/TeensyID.h
@@ -107,4 +107,11 @@ void teensyUID64(uint8_t *uid64);
   */
 const char* teensyUID64(void);
 
+/** Teensy Board Version
+  *
+  * @returns
+  * A string containing the board name as specified on https://www.pjrc.com/teensy/
+  */ 
+const char* teensyBoardVersion(void);
+
 #endif

--- a/examples/ReadAll/ReadAll.ino
+++ b/examples/ReadAll/ReadAll.ino
@@ -57,6 +57,7 @@ void setup() {
   Serial.printf("String 128-bit UniqueID from chip: %s\n", kinetisUID());
   Serial.printf("Array 128-bit UUID RFC4122: %02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X\n", uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
   Serial.printf("String 128-bit UUID RFC4122: %s\n", teensyUUID());
+  Serial.printf("Board Model: %s\n", teensyBoardVersion());
   }
 
 void loop() {}

--- a/examples/T4_ReadAll/T4_ReadAll.ino
+++ b/examples/T4_ReadAll/T4_ReadAll.ino
@@ -53,6 +53,7 @@ void setup() {
   Serial.printf("String MAC Address: %s\n", teensyMAC());
   Serial.printf("UID 64-bit: %02X-%02X-%02X-%02X-%02X-%02X-%02X-%02X\n", uid64[0], uid64[1], uid64[2], uid64[3], uid64[4], uid64[5], uid64[6], uid64[7]);
   Serial.printf("UID 64-bit: %s\n", teensyUID64());
+  Serial.printf("Board Model: %s\n", teensyBoardVersion());
   }
 
 void loop() {}


### PR DESCRIPTION
# Description 

This PR addresses issue #9 I opened about getting the board version with this library.


# What it does
You can now call `teensyBoardVersion();` and it returns a string containing the version of the Teensy board you are using. It is formatted exactly as seen on the [PJRC Website](https://www.pjrc.com/teensy/) so If you are using a Teensy 4 for example, it would return `Teensy 4.0`

# Testing
I have tested this code on the following boards:
- Teensy 3.0
- Teensy 3.1
- Teensy 4.0

I don't have any of the other boards laying around to test with. Because it's just searching for if a macro is defined, it won't break anything if a someone uses a board that wasn't defined here.

Also, there's an else clause at the end so if an undefined Teensy board is used with this library, it will just return `Unknown Teensy` and won't break anything. 


I hope this gets implemented because then I can just ditch my library and point people here instead =D